### PR TITLE
JR | Adds gradle build tool to remove dependency on netbeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Gradle 
+.gradletasknamecache
+.gradle/
+build/
+bin/
+
 /logs/**
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ At the end of the execution of these SQLs, you should have installed a database 
 
 Configure the IP you want to use for your MapleStory server in "configuration.ini" file, or set it as "localhost" if you want to run it only on your machine. Alternatively, you can use the IP given by Hamachi to use on a Hamachi network, or you can use a non-Hamachi method of port-forwarding. Neither will be approached here.
 
+#### The following is no longer necessary. You may skip to "Building the JAR" or you can continue using the old method.
 Now open NetBeans, and click "Open a project..." . Select then the "HeavenMS" folder, that should already be a project recognizable by NetBeans. If it isn't, you have a problem.
 
 #### Inside the project, you may encounter some code errors.
@@ -115,6 +116,17 @@ Locate the "cores" folder inside the root directory of this project and manually
 Also, a new Java7 platform must be defined to run the server. Click "Manage Platforms...", then "Add platform", browse through until you locate the Java7 folder in the file system, it should be at "C:\Program Files\Java". Then, name this new platform "JDK 1.7".
 
 Finally, select "Clean and Build project" to build the JAR file for the MapleStory server. Once done, make sure both WampServer and Hamachi are on and functional, then execute "launch.bat" on the root of the project. If no errors were raised from this action, your MapleStory server is now online.
+
+---
+### Building the JAR (New Method)
+
+`./gradlew clean build` To construct the jar
+
+The jar is now located at `build/dist`
+
+### Running the Server
+
+Run `launch.bat`
 
 ---
 ### Installing the CLIENT 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ Finally, select "Clean and Build project" to build the JAR file for the MapleSto
 ---
 ### Building the JAR (New Method)
 
-`./gradlew clean build` To construct the jar
+To construct the jar
+`./gradlew clean build` 
 
 The jar is now located at `build/dist`
+
+To construct the jar and copy it to the `dist/` directory
+`./gradlew buildAndCopy`
 
 ### Running the Server
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,16 @@ sourceSets {
 tasks.withType(JavaCompile) {
     options.bootClasspath = "$JDK7_HOME/jre/lib/rt.jar;$JDK7_HOME/jre/lib/jce.jar"
 }
+
+task copyJarToDist(type: Copy) {
+    from 'build/dist/MapleSolaxia.jar'
+    into 'dist'
+}
+
+task buildAndCopy {
+    dependsOn clean
+    dependsOn build
+
+    build.mustRunAfter clean
+    finalizedBy copyJarToDist
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,28 @@
+apply plugin: 'java'
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+project.archivesBaseName = 'MapleSolaxia' // Temporary
+project.libsDirName = 'dist'
+compileJava.options.bootClasspath = "C:/Program Files/Java/jdk1.7.0_79/jre/lib/rt.jar;C:/Program Files/Java/jdk1.7.0_79/jre/lib/jce.jar"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly  'com.zaxxer:HikariCP-java7:2.4.12'
+    compileOnly  'org.apache.directory.studio:org.apache.mina.core:2.0.7'
+    compileOnly  'mysql:mysql-connector-java:5.1.6'
+    compileOnly  'org.slf4j:slf4j-api:1.6.6'
+    compileOnly  'org.slf4j:slf4j-jdk14:1.7.5'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src'
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ targetCompatibility = 1.7
 
 project.archivesBaseName = 'MapleSolaxia' // Temporary
 project.libsDirName = 'dist'
-compileJava.options.bootClasspath = "C:/Program Files/Java/jdk1.7.0_79/jre/lib/rt.jar;C:/Program Files/Java/jdk1.7.0_79/jre/lib/jce.jar"
 
 repositories {
     mavenCentral()
@@ -25,4 +24,8 @@ sourceSets {
             srcDir 'src'
         }
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.bootClasspath = "$JDK7_HOME/jre/lib/rt.jar;$JDK7_HOME/jre/lib/jce.jar"
 }

--- a/launch.bat
+++ b/launch.bat
@@ -1,5 +1,5 @@
 @echo off
 @title ProjectNano
-set CLASSPATH=.;build\dist\*;cores\*
+set CLASSPATH=.;dist\*;cores\*
 java -Xmx2048m -Dwzpath=wz\ net.server.Server
 pause

--- a/launch.bat
+++ b/launch.bat
@@ -1,5 +1,5 @@
 @echo off
 @title ProjectNano
-set CLASSPATH=.;dist\*
+set CLASSPATH=.;build\dist\*;cores\*
 java -Xmx2048m -Dwzpath=wz\ net.server.Server
 pause


### PR DESCRIPTION
#8 
* Requires gradle in order to build
* UNIX based systems can run `yum install gradle` or `brew install gradle`
* Windows based system can use Chocolately command choco install gradle
  or alternatively download gradle.msi
* `./gradlew clean build` will build the jar into `build/dist` directory
* You no longer need to move the jar to the `dist/` directory
* launch.bat will now look for the jar files in the `cores/` directory
* After building, run the launch.bat to run the server as usual