### PR TITLE
JR | Updates the method call with the proper value to prevent a stack trace from printing

### DIFF
--- a/scripts/npc/2100002.js
+++ b/scripts/npc/2100002.js
@@ -6,6 +6,6 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    cm.openShopNPC(48);
+    cm.openShopNPC(2100002);
     cm.dispose();
 }

--- a/scripts/npc/2100003.js
+++ b/scripts/npc/2100003.js
@@ -6,6 +6,6 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    cm.openShopNPC(52);
+    cm.openShopNPC(2100003);
     cm.dispose();
 }


### PR DESCRIPTION
#3 

* NPCs Zaid and Jasmine both were printing a stack trace
* Changed the passed values to the NPC ID to fix that